### PR TITLE
disable compression in tests

### DIFF
--- a/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/AdaptiveQueryExecSuite.scala
@@ -135,6 +135,7 @@ class AdaptiveQueryExecSuite
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1") // force shuffle exchange
+        .set(SQLConf.PARQUET_COMPRESSION.key, "uncompressed")
 
     withGpuSparkSession(spark => {
       import spark.implicits._
@@ -183,6 +184,7 @@ class AdaptiveQueryExecSuite
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(SQLConf.ADAPTIVE_EXECUTION_FORCE_APPLY.key, "true")
+        .set(SQLConf.PARQUET_COMPRESSION.key, "uncompressed")
 
     withGpuSparkSession(spark => {
       import spark.implicits._
@@ -225,6 +227,7 @@ class AdaptiveQueryExecSuite
       // the read will still happen on GPU with a CPU write
       .set(RapidsConf.TEST_ALLOWED_NONGPU.key, "DataWritingCommandExec")
       .set("spark.rapids.sql.exec.DataWritingCommandExec", "false")
+      .set(SQLConf.PARQUET_COMPRESSION.key, "uncompressed")
 
       withGpuSparkSession(spark => {
         import spark.implicits._
@@ -268,6 +271,7 @@ class AdaptiveQueryExecSuite
     val conf = new SparkConf()
         .set(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key, "true")
         .set(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key, "-1")
+        .set(SQLConf.PARQUET_COMPRESSION.key, "uncompressed")
 
     withGpuSparkSession(spark => {
       setupTestData(spark)
@@ -305,6 +309,7 @@ class AdaptiveQueryExecSuite
       .set(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES.key, "50")
       // disable DemoteBroadcastHashJoin rule from removing BHJ due to empty partitions
       .set(SQLConf.NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN.key, "0")
+      .set(SQLConf.PARQUET_COMPRESSION.key, "uncompressed")
 
     withGpuSparkSession(spark => {
       setupTestData(spark)
@@ -334,6 +339,7 @@ class AdaptiveQueryExecSuite
       // disable DemoteBroadcastHashJoin rule from removing BHJ due to empty partitions
       .set(SQLConf.NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN.key, "0")
       .set(RapidsConf.ENABLE_CAST_STRING_TO_INTEGER.key, "true")
+      .set(SQLConf.PARQUET_COMPRESSION.key, "uncompressed")
 
     withGpuSparkSession(spark => {
       setupTestData(spark)
@@ -374,6 +380,7 @@ class AdaptiveQueryExecSuite
       .set(SQLConf.NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN.key, "0")
       .set(SQLConf.SHUFFLE_PARTITIONS.key, "5")
       .set(RapidsConf.ENABLE_CAST_STRING_TO_INTEGER.key, "true")
+      .set(SQLConf.PARQUET_COMPRESSION.key, "uncompressed")
 
     withGpuSparkSession(spark => {
       setupTestData(spark)


### PR DESCRIPTION
Signed-off-by: Andy Grove <andygrove@nvidia.com>

Disable compression in tests to make the tests more deterministic.